### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.3-onbuild
+
+EXPOSE 9102
+EXPOSE 9125
+
+VOLUME ["/mapping.conf"]
+
+ENTRYPOINT ["/go/bin/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.3-onbuild
 
 EXPOSE 9102
-EXPOSE 9125
+EXPOSE 9125/udp
 
 VOLUME ["/mapping.conf"]
 

--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ follows:
      
     test.web-server.foo.bar (gauge)
      => test_web__server_foo_bar_gauge{}
+
+## Docker
+
+```
+docker run -d --name="statsd_bridge" \
+  -p 9102:9102 \
+  -p 9125:9125 \
+  -v /path/on/host/to/mapping.conf:/mapping.conf \
+  statsd_bridge -statsd.mapping-config="/mapping.conf"
+```

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ follows:
 ## Docker
 
 ```
-docker run -d --name="statsd_bridge" \
+docker run -d --name="statsd-bridge" \
   -p 9102:9102 \
   -p 9125:9125 \
   -v /path/on/host/to/mapping.conf:/mapping.conf \
-  statsd_bridge -statsd.mapping-config="/mapping.conf"
+  statsd-bridge -statsd.mapping-config="/mapping.conf"
 ```

--- a/mapper.go
+++ b/mapper.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	identifierRE = `[a-zA-Z_][a-zA-Z0-9_]+`
+	identifierRE = `[a-zA-Z_-][a-zA-Z0-9_-]+`
 	metricLineRE = regexp.MustCompile(`^(\*\.|` + identifierRE + `\.)+(\*|` + identifierRE + `)$`)
 	labelLineRE  = regexp.MustCompile(`^(` + identifierRE + `)\s*=\s*"(.*)"$`)
 	metricNameRE = regexp.MustCompile(`^` + identifierRE + `$`)


### PR DESCRIPTION
This also allows for `-` to be in the metric name.

You can also publish a docker image to the `prom` organization now with this pull request.