### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+
+EXPOSE      9102 9125/udp

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -49,19 +49,22 @@ ifeq ($(GOOS),darwin)
 endif
 
 GO_VERSION ?= 1.4.2
-
-ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
-	GOROOT := $(shell go env GOROOT)
-else
-	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
-endif
-
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOCC       ?= $(GOROOT)/bin/go
-GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ In general, the different metric types are translated as follows, with certain
 suffixes appended to the Prometheus metric names:
 
     StatsD gauge   -> Prometheus gauge (suffix `_gauge`)
-    
+
     StatsD counter -> Prometheus counter (suffix `_counter`)
-    
+
     StatsD timer   -> Prometheus summary (suffix `_timer`)        <-- indicates timer quantiles
                    -> Prometheus counter (suffix `_timer_total`)  <-- indicates total time spent
                    -> Prometheus counter (suffix `_timer_count`)  <-- indicates total number of timer events
@@ -76,21 +76,35 @@ An example mapping configuration:
     action="$2"
     outcome="$3"
     job="test_dispatcher"
-    
+
     *.signup.*.*
     name="signup_events"
     provider="$2"
     outcome="$3"
     job="${1}_server"
-    
+
 This would transform these example StatsD metrics into Prometheus metrics as
 follows:
 
     test.dispatcher.FooProcessor.send.success (counter)
      => dispatcher_events_counter{processor="FooProcessor", action="send", outcome="success", job="test_dispatcher"}
-    
+
     foo_product.signup.facebook.failure (counter)
      => signup_events_counter{provider="facebook", outcome="failure", job="foo_product_server"}
-     
+
     test.web-server.foo.bar (gauge)
      => test_web__server_foo_bar_gauge{}
+
+## Using Docker
+
+You can deploy this exporter using the [prom/statsd-bridge](https://registry.hub.docker.com/u/prom/statsd-bridge/) Docker image.
+
+For example:
+
+```bash
+docker pull prom/statsd-bridge
+
+docker run -d -p 9102:9102 -p 9125/udp:9125/udp \
+        -v $PWD/statsd_mapping.conf:/tmp/statsd_mapping.conf \
+        prom/statsd-bridge -statsd.mapping-config=/tmp/statsd_mapping.conf
+```


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/statsd-bridge/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@juliusv @discordianfish 