### PR TITLE
allow metrics with dashes when mapping

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -24,8 +24,10 @@ import (
 )
 
 var (
-	identifierRE = `[a-zA-Z_][a-zA-Z0-9_]+`
-	metricLineRE = regexp.MustCompile(`^(\*\.|` + identifierRE + `\.)+(\*|` + identifierRE + `)$`)
+	identifierRE   = `[a-zA-Z_][a-zA-Z0-9_]+`
+	statsdMetricRE = `[a-zA-Z_](-?[a-zA-Z0-9_])+`
+
+	metricLineRE = regexp.MustCompile(`^(\*\.|` + statsdMetricRE + `\.)+(\*|` + statsdMetricRE + `)$`)
 	labelLineRE  = regexp.MustCompile(`^(` + identifierRE + `)\s*=\s*"(.*)"$`)
 	metricNameRE = regexp.MustCompile(`^` + identifierRE + `$`)
 )

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -35,6 +35,13 @@ func TestMetricMapper(t *testing.T) {
 				result="$3"
 				job="test_dispatcher"
 
+				test.my-dispatch-host01.name.dispatcher.*.*.*
+				name="host_dispatch_events"
+				processor="$1"
+				action="$2"
+				result="$3"
+				job="test_dispatcher"
+
 				*.*
 				name="catchall"
 				first="$1"
@@ -45,6 +52,13 @@ func TestMetricMapper(t *testing.T) {
 			mappings: map[string]map[string]string{
 				"test.dispatcher.FooProcessor.send.succeeded": map[string]string{
 					"name":      "dispatch_events",
+					"processor": "FooProcessor",
+					"action":    "send",
+					"result":    "succeeded",
+					"job":       "test_dispatcher",
+				},
+				"test.my-dispatch-host01.name.dispatcher.FooProcessor.send.succeeded": map[string]string{
+					"name":      "host_dispatch_events",
 					"processor": "FooProcessor",
 					"action":    "send",
 					"result":    "succeeded",
@@ -91,7 +105,7 @@ func TestMetricMapper(t *testing.T) {
 		// Config with bad metric line.
 		{
 			config: `
-				bad-metric-line.*.*
+				bad--metric-line.*.*
 				name="foo"
 			`,
 			configBad: true,
@@ -101,6 +115,14 @@ func TestMetricMapper(t *testing.T) {
 			config: `
 				test.*.*
 				name=foo
+			`,
+			configBad: true,
+		},
+		// Config with bad label line.
+		{
+			config: `
+				test.*.*
+				name="foo-name"
 			`,
 			configBad: true,
 		},


### PR DESCRIPTION
It wasn't entirely clear why this wasn't allowed. We have some systems that submit metrics with their hostname in the metric. Something in the form of `test-myhost01`. This allows the mapper to match those.

Actually doesn't fully meet the use case where the name may be `test-my-host01` or something. Still working.