### PR TITLE
add root endpoint with redirect

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,15 @@ var (
 
 func serveHTTP() {
 	http.Handle(*metricsEndpoint, prometheus.Handler())
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>StatsD Bridge</title></head>
+			<body>
+			<h1>StatsD Bridge</h1>
+			<p><a href="` + *metricsEndpoint + `">Metrics</a></p>
+			</body>
+			</html>`))
+	})
 	http.ListenAndServe(*listenAddress, nil)
 }
 


### PR DESCRIPTION
Adds a root endpoint similar to [haproxy exporter](https://github.com/prometheus/haproxy_exporter/blob/master/haproxy_exporter.go#L391-L398) and [node exporter](https://github.com/prometheus/node_exporter/blob/master/node_exporter.go#L179-L187)